### PR TITLE
Fix for Linux

### DIFF
--- a/cbits/conv.c
+++ b/cbits/conv.c
@@ -1,24 +1,28 @@
+#define _GNU_SOURCE
 #include <time.h>
 #include <locale.h>
 #include <xlocale.h>
 
 locale_t c_locale = NULL;
 
-locale_t init_locale() {
-    if (c_locale == NULL) c_locale = newlocale(LC_ALL_MASK, NULL, NULL);
+void init_locale() {
+    if (c_locale == NULL) {
+        c_locale = newlocale(LC_ALL_MASK, NULL, NULL);
+        uselocale(c_locale);
+    }
 }
 
 time_t c_parse_unix_time(char *fmt, char *src) {
     struct tm dst;
     init_locale();
-    strptime_l(src, fmt, &dst, c_locale);
+    strptime(src, fmt, &dst);
     return mktime(&dst);
 }
 
 time_t c_parse_unix_time_gmt(char *fmt, char *src) {
     struct tm dst;
     init_locale();
-    strptime_l(src, fmt, &dst, c_locale);
+    strptime(src, fmt, &dst);
     return timegm(&dst);
 }
 
@@ -26,12 +30,12 @@ void c_format_unix_time(char *fmt, time_t src, char* dst, int siz) {
     struct tm tim;
     init_locale();
     localtime_r(&src, &tim);
-    strftime_l(dst, siz, fmt, &tim, c_locale);
+    strftime(dst, siz, fmt, &tim);
 }
 
 void c_format_unix_time_gmt(char *fmt, time_t src, char* dst, int siz) {
     struct tm tim;
     init_locale();
     gmtime_r(&src, &tim);
-    strftime_l(dst, siz, fmt, &tim, c_locale);
+    strftime(dst, siz, fmt, &tim);
 }

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -4,12 +4,11 @@
   % runghc -i.. Test.hs
 -}
 
-module Test where
-
 import qualified Data.ByteString.Char8 as BS
 import Data.UnixTime
 import System.Locale
 import System.Time hiding (toClockTime)
+import System.Posix.Env (setEnv)
 import Test.Framework (defaultMain, testGroup, Test)
 import Test.Framework.Providers.HUnit
 import Test.HUnit hiding (Test)
@@ -97,4 +96,6 @@ test_diffTime = do
 ----------------------------------------------------------------
 
 main :: Assertion
-main = defaultMain tests
+main = do
+    setEnv "TZ" "UTC-9" True
+    defaultMain tests


### PR DESCRIPTION
strptime_l and strftime_l are missing many platforms, including linux, so avoid using them.
strptime and strftime are thread-safe.
