### PR TITLE
Addition of a Real instance for UnixDiffTime

### DIFF
--- a/Data/UnixTime/Diff.hs
+++ b/Data/UnixTime/Diff.hs
@@ -37,6 +37,11 @@ instance Num UnixDiffTime where
 
 {-# RULES "Integral->UnixDiffTime" fromIntegral = secondsToUnixDiffTime #-}
 
+instance Real UnixDiffTime where
+        toRational = toFractional
+
+{-# RULES "UnixDiffTime->Fractional" realToFrac = toFractional #-}
+
 ----------------------------------------------------------------
 
 -- | Calculating difference between two 'UnixTime'.
@@ -84,3 +89,7 @@ slowAjust sec usec = (sec + fromIntegral s, usec - u)
 
 secondMicro :: Integral a => a -> (a,a)
 secondMicro usec = usec `quotRem` 1000000
+
+toFractional :: Fractional a => UnixDiffTime -> a
+toFractional (UnixDiffTime s u) = realToFrac s + realToFrac u / 1000000
+{-# SPECIALIZE toFractional :: UnixDiffTime -> Double #-}

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -26,6 +26,7 @@ tests = [
        , testCase "toClockTime" test_toClockTime
        , testCase "diffTime" test_diffTime
        , testCase "diffTimeFromSeconds" test_diffTimeFromSeconds
+       , testCase "diffTimeToSeconds" test_diffTimeToSeconds
        ]
   ]
 
@@ -108,6 +109,16 @@ test_diffTimeFromSeconds = do
     res1 = addUnixDiffTime base 4
     res2 = addUnixDiffTime base (secondsToUnixDiffTime 4)
     res3 = addUnixDiffTime base (microSecondsToUnixDiffTime 4000000)
+
+----------------------------------------------------------------
+
+test_diffTimeToSeconds :: Assertion
+test_diffTimeToSeconds = do
+    res @?= ans
+  where
+    ans :: Rational
+    ans = -12.345678
+    res = realToFrac $ microSecondsToUnixDiffTime (-12345678 :: Int)
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
The motivation is: I want to convert a UnixDiffTime to a Double representing seconds. With a Real instance I can use (realToFrac :: UnixDiffTIme -> Double).

This pull request contains 3 commits:

The first commit modifies the Num instance so that (1::UnixDiffTime) now means 1 second, not 1 microsecond.

The second commit changes the types of secondsToUnixDiffTime and microsecondsToUnixDiffTime. This is to cover the conversion from Integer to UnixDiffTime the above commit removes.

The last commit introduces a Real instance.

Thanks in advance for consideration.
