### PR TITLE
Fix test failure on Debian GNU/kFreeBSD (and probably GNU/Hurd)

### DIFF
--- a/cbits/conv.c
+++ b/cbits/conv.c
@@ -22,7 +22,7 @@
 locale_t c_locale = NULL;
 
 void init_locale() {
-    if (c_locale == NULL) c_locale = newlocale(LC_TIME_MASK, NULL, NULL);
+    if (c_locale == NULL) c_locale = newlocale(LC_TIME_MASK, "C", NULL);
 }
 #else
 void init_locale() {


### PR DESCRIPTION
This pair of commits fixes a compiler warning and a test failure on at least Debian GNU/kFreeBSD (which uses the FreeBSD kernel but the GNU libc):

  https://buildd.debian.org/status/fetch.php?pkg=haskell-unix-time&arch=kfreebsd-amd64&ver=0.1.2-3&stamp=1370013165

The GNU/Hurd failure looks similar, and I expect this to fix it too:

  https://buildd.debian.org/status/fetch.php?pkg=haskell-unix-time&arch=hurd-i386&ver=0.1.2-3%2Bb1&stamp=1371051034
