### PR TITLE
Include terminating '\0' for reallocBytes

### DIFF
--- a/Data/UnixTime/Conv.hs
+++ b/Data/UnixTime/Conv.hs
@@ -95,7 +95,7 @@ formatUnixTimeHelper formatFun fmt (UnixTime sec _) =
         let siz = 80
         ptr  <- mallocBytes siz
         len  <- liftM fromIntegral (formatFun cfmt sec ptr (fromIntegral siz))
-        ptr' <- reallocBytes ptr len
+        ptr' <- reallocBytes ptr (len + 1)
         unsafePackMallocCString ptr' -- FIXME: Use unsafePackMallocCStringLen from bytestring-0.10.2.0
 
 ----------------------------------------------------------------


### PR DESCRIPTION
Since `len` is length of formatted string without terminating '\0',
there is no guarantee that the result string by reallocBytes contains '\0'.
