### PR TITLE
Embedd timegm function for Solaris that doesn't have the function.

### DIFF
--- a/cbits/config.h.in
+++ b/cbits/config.h.in
@@ -2,6 +2,7 @@
 #define __CONFIG_H__
 
 #undef HAVE_STRPTIME_L
+#undef HAVE_TIMEGM
 
 #undef IS_LINUX
 

--- a/cbits/conv.c
+++ b/cbits/conv.c
@@ -46,6 +46,47 @@ time_t c_parse_unix_time(char *fmt, char *src) {
     return mktime(&dst);
 }
 
+#if !defined(HAVE_TIMEGM)
+/* This part is for Solaris that doesn't have timegm.
+ * The copyright notice of timegm and is_leap is as below:
+ *
+ * Copyright (c) 1997 Kungliga Tekniska H.gskolan
+ * (Royal Institute of Technology, Stockholm, Sweden).
+ * All rights reserved. 
+ */
+
+static int
+is_leap(unsigned y)
+{
+  y += 1900;
+  return (y % 4) == 0 && ((y % 100) != 0 || (y % 400) == 0);
+}
+
+static time_t
+timegm (struct tm *tm)
+{
+  static const unsigned ndays[2][12] ={
+    {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31},
+    {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}};
+  time_t res = 0;
+  unsigned i;
+
+  for (i = 70; i < tm->tm_year; ++i)
+    res += is_leap(i) ? 366 : 365;
+
+  for (i = 0; i < tm->tm_mon; ++i)
+    res += ndays[is_leap(tm->tm_year)][i];
+  res += tm->tm_mday - 1;
+  res *= 24;
+  res += tm->tm_hour;
+  res *= 60;
+  res += tm->tm_min;
+  res *= 60;
+  res += tm->tm_sec;
+  return res;
+}
+#endif /* HAVE_TIMEGM */
+
 time_t c_parse_unix_time_gmt(char *fmt, char *src) {
     struct tm dst;
     init_locale();

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AC_DISABLE_OPTION_CHECKING
 AC_CONFIG_HEADER(cbits/config.h)
 
 AC_CHECK_FUNCS(strptime_l)
+AC_CHECK_FUNCS(timegm)
 
 host=`uname -a`
 case $host in


### PR DESCRIPTION
山本さん、今日 Twitter でお話しさせていただいた @unnohideyuki です。突然失礼しました。

Solaris のように timegm を持たないプラットフォーム向けに、HAVE_TIMEGM が define されていない場合には 
conv.c にうめこんだコードが用いられるようにしました。

configure.ac, cbits/config.h.in および cbits/conv.c を commit しましたが、configure は含めていません。
（Merge して頂いたあとに、山本さんの方で autoconf された結果の configure が commit されることを期待しています）

なお、Ubuntu, SPARC Solaris 11 の 2 system 上で cabal test が通ることを確認済です。

Ubuntu:
$ ghc --version
The Glorious Glasgow Haskell Compilation System, version 7.6.3
$ uname -srvmpio
Linux 2.6.38-11-generic #50-Ubuntu SMP Mon Sep 12 21:17:25 UTC 2011 x86_64 x86_64 x86_64 GNU/Linux

SPARC Solaris 11: (カーネルは開発中のものなので表示していません)
$ ghc --version
The Glorious Glasgow Haskell Compilation System, version 7.6.3
$ uname -srmp
SunOS 5.11 sun4v sparc

お手数おかけしてしまいますが、よろしくお願いします。
## 以下はコミットメッセージです。

I modified three files - configure.ac, cbits/config.h.in and cbits/conv.c.

By the modification of configure.ac and cbits/config.h, HAVE_TIMEGM will be or not be defined depending on the presense of the function.
In cbits/conv.c, embedded timegm will be used if the HAVE_TIMEGM is not defined.

The embedded code was from the following URL:

 ftp://ftp.smr.ru/pub/0/FreeBSD/releases/i386/branches/-current/src/crypto/heimdal/lib/asn1/timegm.c

The license of it is the same as that of unix-time (BSD).

embedd timegm code for Solaris.

modified to use AC_CHECK_FUNCS, not the predefined **sun**

In the first modification, I used "#if defined(**sun**)" to switch, however, it was not good.
In this revision, I put AC_CHECK_FUNCS(timegm) in the configure.ac and use "HAVE_TIMEGM" in conv.c.

I also had to modify cbits/config.h.in.
