### PR TITLE
Include xlocale.h only if it exists

### DIFF
--- a/cbits/conv.c
+++ b/cbits/conv.c
@@ -17,7 +17,9 @@
 #include <locale.h>
 
 #if THREAD_SAFE
+#if HAVE_XLOCALE_H
 #include <xlocale.h>
+#endif
 
 locale_t c_locale = NULL;
 

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,8 @@ AC_DISABLE_OPTION_CHECKING
 
 AC_CONFIG_HEADER(cbits/config.h)
 
+AC_CHECK_HEADERS(xlocale.h)
+
 AC_CHECK_FUNCS(strptime_l)
 AC_CHECK_FUNCS(timegm)
 


### PR DESCRIPTION
NetBSD does not have `xlocale.h`.

Note that I did not update `configure` and `cbits/config.h.in` since there are many differences between original files and those I generated by autoreconf.

After the fix and `autoreconf`, all tests passed on NetBSD.
