### PR TITLE
Include cbits in cabal file to fix cabal builds

### DIFF
--- a/unix-time.cabal
+++ b/unix-time.cabal
@@ -27,6 +27,7 @@ Library
                       , old-time
                       , binary
   C-Sources:            cbits/conv.c
+  include-dirs:         cbits
 
 Test-Suite doctest
   Type:                 exitcode-stdio-1.0


### PR DESCRIPTION
This amends the cabal file to work with cabal 2.2.0.0 as described in #41. Tested on v0.3.7 and master with `cabal new-build`. Fixes build failures due to "fatal error: config.h: No such file or directory".