### PR TITLE
Add build-tools dependency on hsc2hs

### DIFF
--- a/unix-time.cabal
+++ b/unix-time.cabal
@@ -36,6 +36,7 @@ Library
                       , bytestring
                       , old-time
                       , binary
+  Build-Tools:          hsc2hs
   C-Sources:            cbits/conv.c
   if os(windows)
     C-Sources:          cbits/strftime.c


### PR DESCRIPTION
I'm currently experiencing Travis build failures for `unix-time-0.4.3` on GHC 7.10.3 with `cabal new-build`, as shown [here](https://travis-ci.org/ku-fpg/remote-monad/jobs/471389899#L1259):

```
Preprocessing library unix-time-0.4.3...
setup: The program 'hsc2hs' is required but it could not be found
```

I believe this is because `new-build` requires `unix-time.cabal` to declare an explicit dependency on `hsc2hs` in its `build-tools`. This patch adds just that.