### PR TITLE
Fix win7

### DIFF
--- a/cbits/config.h.in
+++ b/cbits/config.h.in
@@ -21,6 +21,12 @@
 /* Define to 1 if you have the `strptime_l' function. */
 #undef HAVE_STRPTIME_L
 
+/* Define to 1 if you have the `strtoll_l' function. */
+#undef HAVE_STRTOLL_L
+
+/* Define to 1 if you have the `strtol_l' function. */
+#undef HAVE_STRTOL_L
+
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #undef HAVE_SYS_STAT_H
 
@@ -30,41 +36,38 @@
 /* Define to 1 if you have the `timegm' function. */
 #undef HAVE_TIMEGM
 
-/* Define to 1 if you have the `_mkgmtime' function. */
-#undef HAVE__MKGMTIME
-
-/* Define to 1 if you have the `_get_current_locale' function. */
-#undef HAVE__GET_CURRENT_LOCALE
-
-/* Define to 1 if you have the `_create_locale' function. */
-#undef HAVE__CREATE_LOCALE
-
-/* Define to 1 if you have the `strtol_l' function. */
-#undef HAVE_STRTOL_L
-
-/* Define to 1 if you have the `strtoll_l' function. */
-#undef HAVE_STRTOLL_L
-
-/* Define to 1 if you have the `isspace_l' function. */
-#undef HAVE__ISSPACE_L
-
-/* Define to 1 if you have the `isupper_l' function. */
-#undef HAVE__ISUPPER_L
-
-/* Define to 1 if you have the `isdigit_l' function. */
-#undef HAVE__ISDIGIT_L
-
-/* Define to 1 if you have the `isblank_l' function. */
-#undef HAVE__ISBLANK_L
-
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
 /* Define to 1 if you have the <xlocale.h> header file. */
 #undef HAVE_XLOCALE_H
 
+/* Define to 1 if you have the `_create_locale' function. */
+#undef HAVE__CREATE_LOCALE
+
+/* Define to 1 if you have the `_get_current_locale' function. */
+#undef HAVE__GET_CURRENT_LOCALE
+
+/* Define to 1 if you have the `_isblank_l' function. */
+#undef HAVE__ISBLANK_L
+
+/* Define to 1 if you have the `_isdigit_l' function. */
+#undef HAVE__ISDIGIT_L
+
+/* Define to 1 if you have the `_isspace_l' function. */
+#undef HAVE__ISSPACE_L
+
+/* Define to 1 if you have the `_isupper_l' function. */
+#undef HAVE__ISUPPER_L
+
+/* Define to 1 if you have the `_mkgmtime' function. */
+#undef HAVE__MKGMTIME
+
 /* "Is Linux" */
 #undef IS_LINUX
+
+/* "Is Windows NT 6.1" */
+#undef IS_NT61
 
 /* Define to the address where bug reports for this package should be sent. */
 #undef PACKAGE_BUGREPORT

--- a/cbits/config.h.in
+++ b/cbits/config.h.in
@@ -36,11 +36,26 @@
 /* Define to 1 if you have the `_get_current_locale' function. */
 #undef HAVE__GET_CURRENT_LOCALE
 
+/* Define to 1 if you have the `_create_locale' function. */
+#undef HAVE__CREATE_LOCALE
+
 /* Define to 1 if you have the `strtol_l' function. */
 #undef HAVE_STRTOL_L
 
 /* Define to 1 if you have the `strtoll_l' function. */
 #undef HAVE_STRTOLL_L
+
+/* Define to 1 if you have the `isspace_l' function. */
+#undef HAVE__ISSPACE_L
+
+/* Define to 1 if you have the `isupper_l' function. */
+#undef HAVE__ISUPPER_L
+
+/* Define to 1 if you have the `isdigit_l' function. */
+#undef HAVE__ISDIGIT_L
+
+/* Define to 1 if you have the `isblank_l' function. */
+#undef HAVE__ISBLANK_L
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H

--- a/cbits/strftime.c
+++ b/cbits/strftime.c
@@ -112,8 +112,8 @@ _patch_strftime(char * __restrict s, size_t maxsize, const char * __restrict for
 {
 #if HAVE__GET_CURRENT_LOCALE
 	return _patch_strftime_l(s, maxsize, format, t, _get_current_locale());
-/*#elif HAVE__CREATE_LOCALE
-	return _patch_strftime_l(s, maxsize, format, t, _create_locale(LC_TIME, "C"));*/
+#elif HAVE__CREATE_LOCALE && !IS_NT61
+	return _patch_strftime_l(s, maxsize, format, t, _create_locale(LC_TIME, "C"));
 #else
 	_locale_t locale;
 	return _patch_strftime_l(s, maxsize, format, t, locale);

--- a/cbits/strftime.c
+++ b/cbits/strftime.c
@@ -112,8 +112,8 @@ _patch_strftime(char * __restrict s, size_t maxsize, const char * __restrict for
 {
 #if HAVE__GET_CURRENT_LOCALE
 	return _patch_strftime_l(s, maxsize, format, t, _get_current_locale());
-#elif HAVE__CREATE_LOCALE
-	return _patch_strftime_l(s, maxsize, format, t, _create_locale(LC_TIME, "C"));
+/*#elif HAVE__CREATE_LOCALE
+	return _patch_strftime_l(s, maxsize, format, t, _create_locale(LC_TIME, "C"));*/
 #else
 	_locale_t locale;
 	return _patch_strftime_l(s, maxsize, format, t, locale);

--- a/cbits/strftime.c
+++ b/cbits/strftime.c
@@ -112,8 +112,11 @@ _patch_strftime(char * __restrict s, size_t maxsize, const char * __restrict for
 {
 #if HAVE__GET_CURRENT_LOCALE
 	return _patch_strftime_l(s, maxsize, format, t, _get_current_locale());
-#else
+#elif HAVE__CREATE_LOCALE
 	return _patch_strftime_l(s, maxsize, format, t, _create_locale(LC_TIME, "C"));
+#else
+	_locale_t locale;
+	return _patch_strftime_l(s, maxsize, format, t, locale);
 #endif
 }
 

--- a/cbits/strptime.c
+++ b/cbits/strptime.c
@@ -712,8 +712,8 @@ strptime(const char * __restrict buf, const char * __restrict fmt,
 {
 #if HAVE__GET_CURRENT_LOCALE
 	return strptime_l(buf, fmt, tm, _get_current_locale());
-/*#elif HAVE__CREATE_LOCALE
-	return strptime_l(buf, fmt, tm, _create_locale(LC_TIME, "C"));*/
+#elif HAVE__CREATE_LOCALE && !IS_NT61
+	return strptime_l(buf, fmt, tm, _create_locale(LC_TIME, "C"));
 #else
 	_locale_t locale;
 	return strptime_l(buf, fmt, tm, locale);

--- a/cbits/strptime.c
+++ b/cbits/strptime.c
@@ -712,7 +712,10 @@ strptime(const char * __restrict buf, const char * __restrict fmt,
 {
 #if HAVE__GET_CURRENT_LOCALE
 	return strptime_l(buf, fmt, tm, _get_current_locale());
-#else
+#elif HAVE__CREATE_LOCALE
 	return strptime_l(buf, fmt, tm, _create_locale(LC_TIME, "C"));
+#else
+	_locale_t locale;
+	return strptime_l(buf, fmt, tm, locale);
 #endif
 }

--- a/cbits/strptime.c
+++ b/cbits/strptime.c
@@ -712,8 +712,8 @@ strptime(const char * __restrict buf, const char * __restrict fmt,
 {
 #if HAVE__GET_CURRENT_LOCALE
 	return strptime_l(buf, fmt, tm, _get_current_locale());
-#elif HAVE__CREATE_LOCALE
-	return strptime_l(buf, fmt, tm, _create_locale(LC_TIME, "C"));
+/*#elif HAVE__CREATE_LOCALE
+	return strptime_l(buf, fmt, tm, _create_locale(LC_TIME, "C"));*/
 #else
 	_locale_t locale;
 	return strptime_l(buf, fmt, tm, locale);

--- a/cbits/win_patch.c
+++ b/cbits/win_patch.c
@@ -12,10 +12,12 @@ long long strtoll_l(const char *nptr, char **endptr, int base, _locale_t locale)
 }
 #endif
 
+#if !HAVE__ISBLANK_L
 inline int isblank_l( int c, _locale_t _loc)
 {
     return ( c == ' ' || c == '\t' );
 }
+#endif
 
 inline int strncasecmp_l(const char *s1, const char *s2, int len, _locale_t _loc) {
     return strncasecmp(s1, s2, len);

--- a/cbits/win_patch.h
+++ b/cbits/win_patch.h
@@ -81,23 +81,23 @@
     1 + TYPE_SIGNED(type))
 #endif /* !defined INT_STRLEN_MAXIMUM */
 
-#if HAVE__ISSPACE_L
-#define isspace_l _isspace_l
-#else
+/* #if HAVE__ISSPACE_L */
+/* #define isspace_l _isspace_l */
+/* #else */
 #define isspace_l(ch, locale) isspace(ch)
-#endif
+/* #endif */
 
-#if HAVE__ISUPPER_L
-#define isupper_l _isupper_l
-#else
+/* #if HAVE__ISUPPER_L */
+/* #define isupper_l _isupper_l */
+/* #else */
 #define isupper_l(ch, locale) isupper(ch)
-#endif
+/* #endif */
 
-#if HAVE__ISDIGIT_L
-#define isdigit_l _isdigit_l
-#else
+/* #if HAVE__ISDIGIT_L */
+/* #define isdigit_l _isdigit_l */
+/* #else */
 #define isdigit_l(ch, locale) isdigit(ch)
-#endif
+/* #endif */
 
 #if !HAVE_STRTOL_L
 long strtol_l(const char *nptr, char **endptr, int base, _locale_t locale);
@@ -149,10 +149,6 @@ struct lc_time_T {
     const char  *md_order;
     const char  *ampm_fmt;
 };
-
-#define isspace_l(ch, locale) isspace(ch)
-#define isupper_l(ch, locale) isupper(ch)
-#define isdigit_l(ch, locale) isdigit(ch)
 
 extern const struct lc_time_T   _C_time_locale;
 

--- a/cbits/win_patch.h
+++ b/cbits/win_patch.h
@@ -81,9 +81,23 @@
     1 + TYPE_SIGNED(type))
 #endif /* !defined INT_STRLEN_MAXIMUM */
 
+#if HAVE__ISSPACE_L
 #define isspace_l _isspace_l
+#else
+#define isspace_l(ch, locale) isspace(ch)
+#endif
+
+#if HAVE__ISUPPER_L
 #define isupper_l _isupper_l
+#else
+#define isupper_l(ch, locale) isupper(ch)
+#endif
+
+#if HAVE__ISDIGIT_L
 #define isdigit_l _isdigit_l
+#else
+#define isdigit_l(ch, locale) isdigit(ch)
+#endif
 
 #if !HAVE_STRTOL_L
 long strtol_l(const char *nptr, char **endptr, int base, _locale_t locale);
@@ -102,7 +116,9 @@ long long strtoll_l(const char *nptr, char **endptr, int base, _locale_t locale)
 #define isleap_sum(a, b)    isleap((a) % 400 + (b) % 400)
 #endif /* !defined isleap_sum */
 
+#if !HAVE__ISBLANK_L
 int isblank_l( int c, _locale_t _loc);
+#endif
 
 int strncasecmp_l(const char *s1, const char *s2, int len, _locale_t _loc);
 

--- a/cbits/win_patch.h
+++ b/cbits/win_patch.h
@@ -81,23 +81,23 @@
     1 + TYPE_SIGNED(type))
 #endif /* !defined INT_STRLEN_MAXIMUM */
 
-/* #if HAVE__ISSPACE_L */
-/* #define isspace_l _isspace_l */
-/* #else */
+#if HAVE__ISSPACE_L
+#define isspace_l _isspace_l
+#else
 #define isspace_l(ch, locale) isspace(ch)
-/* #endif */
+#endif
 
-/* #if HAVE__ISUPPER_L */
-/* #define isupper_l _isupper_l */
-/* #else */
+#if HAVE__ISUPPER_L
+#define isupper_l _isupper_l
+#else
 #define isupper_l(ch, locale) isupper(ch)
-/* #endif */
+#endif
 
-/* #if HAVE__ISDIGIT_L */
-/* #define isdigit_l _isdigit_l */
-/* #else */
+#if HAVE__ISDIGIT_L
+#define isdigit_l _isdigit_l
+#else
 #define isdigit_l(ch, locale) isdigit(ch)
-/* #endif */
+#endif
 
 #if !HAVE_STRTOL_L
 long strtol_l(const char *nptr, char **endptr, int base, _locale_t locale);

--- a/cbits/win_patch.h
+++ b/cbits/win_patch.h
@@ -150,6 +150,10 @@ struct lc_time_T {
     const char  *ampm_fmt;
 };
 
+#define isspace_l(ch, locale) isspace(ch)
+#define isupper_l(ch, locale) isupper(ch)
+#define isdigit_l(ch, locale) isdigit(ch)
+
 extern const struct lc_time_T   _C_time_locale;
 
 int _patch_setenv(const char *var, const char *val, int ovr);

--- a/configure
+++ b/configure
@@ -3326,6 +3326,17 @@ _ACEOF
 fi
 done
 
+for ac_func in _create_locale
+do :
+  ac_fn_c_check_func "$LINENO" "_create_locale" "ac_cv_func__create_locale"
+if test "x$ac_cv_func__create_locale" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE__CREATE_LOCALE 1
+_ACEOF
+
+fi
+done
+
 for ac_func in strtol_l
 do :
   ac_fn_c_check_func "$LINENO" "strtol_l" "ac_cv_func_strtol_l"
@@ -3343,6 +3354,50 @@ do :
 if test "x$ac_cv_func_strtoll_l" = xyes; then :
   cat >>confdefs.h <<_ACEOF
 #define HAVE_STRTOLL_L 1
+_ACEOF
+
+fi
+done
+
+for ac_func in _isspace_l
+do :
+  ac_fn_c_check_func "$LINENO" "_isspace_l" "ac_cv_func__isspace_l"
+if test "x$ac_cv_func__isspace_l" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE__ISSPACE_L 1
+_ACEOF
+
+fi
+done
+
+for ac_func in _isupper_l
+do :
+  ac_fn_c_check_func "$LINENO" "_isupper_l" "ac_cv_func__isupper_l"
+if test "x$ac_cv_func__isupper_l" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE__ISUPPER_L 1
+_ACEOF
+
+fi
+done
+
+for ac_func in _isdigit_l
+do :
+  ac_fn_c_check_func "$LINENO" "_isdigit_l" "ac_cv_func__isdigit_l"
+if test "x$ac_cv_func__isdigit_l" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE__ISDIGIT_L 1
+_ACEOF
+
+fi
+done
+
+for ac_func in _isblank_l
+do :
+  ac_fn_c_check_func "$LINENO" "_isblank_l" "ac_cv_func__isblank_l"
+if test "x$ac_cv_func__isblank_l" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE__ISBLANK_L 1
 _ACEOF
 
 fi

--- a/configure
+++ b/configure
@@ -3419,6 +3419,22 @@ cat >>confdefs.h <<_ACEOF
 #define IS_LINUX $LINUX
 _ACEOF
 
+
+case $host in
+  MINGW??_NT-6.1*)
+	NT61=1
+	;;
+  *)
+	NT61=0
+	;;
+esac
+
+
+cat >>confdefs.h <<_ACEOF
+#define IS_NT61 $NT61
+_ACEOF
+
+
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
 # tests run on this system so they can be shared between configure

--- a/configure.ac
+++ b/configure.ac
@@ -29,4 +29,16 @@ case $host in
 esac
 
 AC_DEFINE_UNQUOTED(IS_LINUX,$LINUX,"Is Linux")
+
+case $host in
+  MINGW??_NT-6.1*)
+	NT61=1
+	;;
+  *)
+	NT61=0
+	;;
+esac
+
+AC_DEFINE_UNQUOTED(IS_NT61,$NT61,"Is Windows NT 6.1")
+
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -10,8 +10,13 @@ AC_CHECK_FUNCS(strptime_l)
 AC_CHECK_FUNCS(timegm)
 AC_CHECK_FUNCS(_mkgmtime)
 AC_CHECK_FUNCS(_get_current_locale)
+AC_CHECK_FUNCS(_create_locale)
 AC_CHECK_FUNCS(strtol_l)
 AC_CHECK_FUNCS(strtoll_l)
+AC_CHECK_FUNCS(_isspace_l)
+AC_CHECK_FUNCS(_isupper_l)
+AC_CHECK_FUNCS(_isdigit_l)
+AC_CHECK_FUNCS(_isblank_l)
 
 host=`uname -a`
 case $host in


### PR DESCRIPTION
...fixes 51
Note that it make the package buildable in windows 7 but the `getUnixTime` is as wrong as in the other windows versions (well, at least in windows 10)
The hack to avoid the issue with `_create_locale` would affect Windows 7 and Windows Server 2008 R2 but i've only tested in the first one.