### PR TITLE
In getUnixTime restrict the seconds field to Word32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-dist
+dist*
 cbits/config.h
+cbits/config.h.in~
 config.log
 config.status
 .cabal-sandbox/
 cabal.sandbox.config
-
+.ghc.environment.*
 # stack
 .stack-work

--- a/Data/UnixTime/Sys.hsc
+++ b/Data/UnixTime/Sys.hsc
@@ -29,11 +29,4 @@ foreign import ccall unsafe "gettimeofday"
 getUnixTime :: IO UnixTime
 getUnixTime = allocaBytes (#const sizeof(struct timeval)) $ \ p_timeval -> do
     throwErrnoIfMinus1_ "getClockTime" $ c_gettimeofday p_timeval nullPtr
-#if defined(_WIN32)
-    sec' <- ((#peek struct timeval,tv_sec)  p_timeval) :: IO Word32
-    let sec = fromIntegral sec'
-#else
-    sec  <- (#peek struct timeval,tv_sec)  p_timeval
-#endif
-    usec <- (#peek struct timeval,tv_usec) p_timeval
-    return $ UnixTime sec usec
+    peek (castPtr p_timeval)

--- a/Data/UnixTime/Sys.hsc
+++ b/Data/UnixTime/Sys.hsc
@@ -8,9 +8,6 @@ import Foreign.C.Types
 import Foreign.Marshal.Alloc
 import Foreign.Ptr
 import Foreign.Storable
-#if defined(_WIN32)
-import Data.Word
-#endif
 
 -- from System.Time
 

--- a/Data/UnixTime/Sys.hsc
+++ b/Data/UnixTime/Sys.hsc
@@ -8,6 +8,9 @@ import Foreign.C.Types
 import Foreign.Marshal.Alloc
 import Foreign.Ptr
 import Foreign.Storable
+#if defined(_WIN32)
+import Data.Word
+#endif
 
 -- from System.Time
 
@@ -26,6 +29,11 @@ foreign import ccall unsafe "gettimeofday"
 getUnixTime :: IO UnixTime
 getUnixTime = allocaBytes (#const sizeof(struct timeval)) $ \ p_timeval -> do
     throwErrnoIfMinus1_ "getClockTime" $ c_gettimeofday p_timeval nullPtr
+#if defined(_WIN32)
+    sec' <- ((#peek struct timeval,tv_sec)  p_timeval) :: IO Word32
+    let sec = fromIntegral sec'
+#else
     sec  <- (#peek struct timeval,tv_sec)  p_timeval
+#endif
     usec <- (#peek struct timeval,tv_usec) p_timeval
     return $ UnixTime sec usec


### PR DESCRIPTION
To fix the ouput of the function for some windows systems. See 