### PR TITLE
Fix SDT and setenv on windows.

### DIFF
--- a/Data/UnixTime/Conv.hs
+++ b/Data/UnixTime/Conv.hs
@@ -71,6 +71,7 @@ parseUnixTimeGMT fmt str = unsafePerformIO $
 -- This is a wrapper for strftime_l().
 -- 'utMicroSeconds' is ignored.
 -- The result depends on the TZ environment variable.
+--
 
 formatUnixTime :: Format -> UnixTime -> IO ByteString
 formatUnixTime fmt t =

--- a/cbits/conv.c
+++ b/cbits/conv.c
@@ -50,7 +50,7 @@ char *set_tz_utc() {
     char *tz;
     tz = getenv("TZ");
 #if defined(_WIN32)
-    _patch_setenv("TZ", "", 1);
+    _patch_setenv("TZ", "UTC", 1);
 #else
     setenv("TZ", "", 1);
 #endif

--- a/cbits/strftime.c
+++ b/cbits/strftime.c
@@ -522,7 +522,8 @@ label:
 #ifdef ALTZONE
 					diff = -altzone;
 #else /* !defined ALTZONE */
-					continue;
+					// Fix the daylight saving time, see #54.
+					diff = -(_timezone - 3600 * t->tm_isdst);
 #endif /* !defined ALTZONE */
 #endif /* !defined TM_GMTOFF */
 				if (diff < 0) {

--- a/cbits/win_patch.c
+++ b/cbits/win_patch.c
@@ -109,9 +109,9 @@ int _patch_setenv(const char *var, const char *val, int _ovr) {
     int len = varlen + vallen + 2;
     char *sname = (char *)malloc(len);
     strcpy(sname, var);
-    sname[strlen(var)] = '=';
+    sname[varlen] = '=';
     strcpy(sname + varlen + 1, val);
-    sname[len + 1] = '\0';
+    sname[varlen + vallen + 1] = '\0';
     int r = _putenv(sname);
     free(sname);
     return r;

--- a/cbits/win_patch.c
+++ b/cbits/win_patch.c
@@ -100,18 +100,26 @@ const struct lc_time_T   _C_time_locale = {
 };
 
 
-int _patch_setenv(const char *var, const char *val, int ovr) {
-    BOOL b = SetEnvironmentVariableA(var, val);
-    if (b) {
-        return 0;
-    } else {
-        return 1;
+int _patch_setenv(const char *var, const char *val, int _ovr) {
+    if (val == NULL) {
+        return _patch_unsetenv(var);
     }
+    int varlen = strlen(var);
+    int vallen = strlen(val);
+    int len = varlen + vallen + 2;
+    char *sname = (char *)malloc(len);
+    strcpy(sname, var);
+    sname[strlen(var)] = '=';
+    strcpy(sname + varlen + 1, val);
+    sname[len + 1] = '\0';
+    int r = _putenv(sname);
+    free(sname);
+    return r;
 }
 
 int _patch_unsetenv(const char *name) {
-    int len = strlen(name);
-    char *sname = (char *)malloc(len + 2);
+    int len = strlen(name) + 2;
+    char *sname = (char *)malloc(len);
     strcpy(sname, name);
     sname[len] = '=';
     sname[len + 1] = '\0';


### PR DESCRIPTION
This pr fixes #54, by handling `tm_isdst` correctly when formatting time that affected by "day saving time".

Along with this pr, the problem of `setenv` on windows also gets fixed. The previous implementation with `SetEnvironmentVariableA` may doesn't affect the execution of `mktime` and `gmtime_s`, leading to error on test case "parseUnixTimeGMT & formatUnixTimeGMT - inverses the result (2)" when `tm_isdst` isn't zero. The previous `parseUnixTimeGMT/formatUnixTimeGMT` also give false results on non-UTC locales.