### PR TITLE
Robustly detect _mkgmtime and _isblank_l on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cabal.sandbox.config
 .ghc.environment.*
 # stack
 .stack-work
+autom4te.cache/*

--- a/cbits/config.h.in
+++ b/cbits/config.h.in
@@ -1,5 +1,9 @@
 /* cbits/config.h.in.  Generated from configure.ac by autoheader.  */
 
+/* Define to 1 if you have the declaration of `_mkgmtime', and to 0 if you
+   don't. */
+#undef HAVE_DECL__MKGMTIME
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 
@@ -59,9 +63,6 @@
 
 /* Define to 1 if you have the `_isupper_l' function. */
 #undef HAVE__ISUPPER_L
-
-/* Define to 1 if you have the `_mkgmtime' function. */
-#undef HAVE__MKGMTIME
 
 /* "Is Linux" */
 #undef IS_LINUX

--- a/cbits/win_patch.h
+++ b/cbits/win_patch.h
@@ -116,7 +116,11 @@ long long strtoll_l(const char *nptr, char **endptr, int base, _locale_t locale)
 #define isleap_sum(a, b)    isleap((a) % 400 + (b) % 400)
 #endif /* !defined isleap_sum */
 
-#if !HAVE__ISBLANK_L
+#if HAVE__ISBLANK_L
+#define isblank_l _isblank_l
+// Needed to avoid -Wimplicit-function-declaration warnings
+int _isblank_l(int c, _locale_t  loc);
+#else
 int isblank_l( int c, _locale_t _loc);
 #endif
 
@@ -126,7 +130,7 @@ struct tm *gmtime_r(const time_t *_time_t, struct tm *_tm);
 
 struct tm *localtime_r(const time_t *_time_t, struct tm *_tm);
 
-#if HAVE__MKGMTIME
+#if HAVE_DECL__MKGMTIME
 #define timegm _mkgmtime
 #define HAVE_TIMEGM 1
 #endif

--- a/configure
+++ b/configure
@@ -651,6 +651,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -721,6 +722,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -973,6 +975,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1110,7 +1121,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1263,6 +1274,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1723,6 +1735,52 @@ $as_echo "$ac_res" >&6; }
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
 } # ac_fn_c_check_func
+
+# ac_fn_c_check_decl LINENO SYMBOL VAR INCLUDES
+# ---------------------------------------------
+# Tests whether SYMBOL is declared in INCLUDES, setting cache variable VAR
+# accordingly.
+ac_fn_c_check_decl ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  as_decl_name=`echo $2|sed 's/ *(.*//'`
+  as_decl_use=`echo $2|sed -e 's/(/((/' -e 's/)/) 0&/' -e 's/,/) 0& (/g'`
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $as_decl_name is declared" >&5
+$as_echo_n "checking whether $as_decl_name is declared... " >&6; }
+if eval \${$3+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$4
+int
+main ()
+{
+#ifndef $as_decl_name
+#ifdef __cplusplus
+  (void) $as_decl_use;
+#else
+  (void) $as_decl_name;
+#endif
+#endif
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  eval "$3=yes"
+else
+  eval "$3=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+eval ac_res=\$$3
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+
+} # ac_fn_c_check_decl
 cat >config.log <<_ACEOF
 This file contains any messages produced by compilers while
 running configure, to aid debugging if configure makes a mistake.
@@ -3304,16 +3362,17 @@ _ACEOF
 fi
 done
 
-for ac_func in _mkgmtime
-do :
-  ac_fn_c_check_func "$LINENO" "_mkgmtime" "ac_cv_func__mkgmtime"
-if test "x$ac_cv_func__mkgmtime" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE__MKGMTIME 1
-_ACEOF
-
+ac_fn_c_check_decl "$LINENO" "_mkgmtime" "ac_cv_have_decl__mkgmtime" "#include <time.h>
+"
+if test "x$ac_cv_have_decl__mkgmtime" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
 fi
-done
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL__MKGMTIME $ac_have_decl
+_ACEOF
 
 for ac_func in _get_current_locale
 do :

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_CHECK_HEADERS(xlocale.h)
 
 AC_CHECK_FUNCS(strptime_l)
 AC_CHECK_FUNCS(timegm)
-AC_CHECK_FUNCS(_mkgmtime)
+AC_CHECK_DECLS([_mkgmtime], [], [], [[#include <time.h>]])
 AC_CHECK_FUNCS(_get_current_locale)
 AC_CHECK_FUNCS(_create_locale)
 AC_CHECK_FUNCS(strtol_l)


### PR DESCRIPTION
GHC 9.4 on Windows switches from using a GCC-based C toolchain to a Clang-based one. This revealed that the way `unix-time`'s `configure.ac` script detects the presence of the `_mkgmtime` and `_isblank_l` functions is fragile, as they depend on MSVCRT-specific assumptions that do not hold when linking against UCRT (as is the case with the Clang-based toolchain). This patch implements the necessary tweaks to make `unix-time` use these functions in a slightly more portable way. See https://github.com/kazu-yamamoto/unix-time/issues/58#issuecomment-1237072121 for a more in-depth look at why this is done this way.

Fixes #58.