### PR TITLE
Windows: Link against `mingwex` to work around GHC#23533

### DIFF
--- a/test/UnixTimeSpec.hs
+++ b/test/UnixTimeSpec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, FlexibleInstances, CPP #-}
+{-# LANGUAGE OverloadedStrings, FlexibleInstances, CPP, TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module UnixTimeSpec (main, spec) where
@@ -12,6 +12,7 @@ import Data.UnixTime
 import Foreign.Ptr (Ptr)
 import Foreign.Marshal.Alloc (alloca)
 import Foreign.Storable (peek, poke)
+import qualified Language.Haskell.TH as TH (runIO)
 import Test.Hspec
 import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck hiding ((===))
@@ -66,6 +67,13 @@ spec = do
             let pokePeek :: Ptr UnixTime -> IO UnixTime
                 pokePeek ptr = poke ptr ut >> peek ptr
             in shouldReturn (alloca pokePeek) ut
+
+    describe "getTimeOfDay" $
+        it "should work in Template Haskell" $
+            $(do time <- TH.runIO getUnixTime
+                 let b = time == time
+                 [| b |])
+            `shouldBe` True
 
 formatMailModel :: UTCTime -> TimeZone -> ByteString
 formatMailModel ut zone = BS.pack $ formatTime defaultTimeLocale fmt zt

--- a/unix-time.cabal
+++ b/unix-time.cabal
@@ -51,6 +51,19 @@ library
     if impl(ghc >=7.8)
         cc-options: -fPIC
 
+    -- GHC 9.4.5, 9.6.1, and 9.6.2 on Windows do not link against mingwex, but
+    -- unix-time implicitly depends on this library due to the use of the
+    -- gettimeofday() function, which comes from mingwex on Windows. To avoid
+    -- linker errors in the absence of a mingwex dependency (see
+    -- https://gitlab.haskell.org/ghc/ghc/-/issues/23533 for an example of
+    -- this), we depend on mingwex explicitly here.
+    --
+    -- Other versions of GHC on Windows already depend on mingwex, so we guard
+    -- this behind appropriate conditionals.
+    if os(windows)
+        if (impl(ghc >= 9.4.5) && !impl(ghc >= 9.4.6)) || (impl(ghc >= 9.6.1) && !impl(ghc >= 9.6.3))
+            extra-libraries: mingwex
+
     if os(windows)
         c-sources:
             cbits/strftime.c
@@ -71,6 +84,7 @@ test-suite spec
         old-locale,
         old-time,
         QuickCheck,
+        template-haskell,
         time,
         unix-time,
         hspec >=2.6


### PR DESCRIPTION
GHC 9.4.5, 9.6.1, and 9.6.2 on Windows do not link against the `mingwex` library, which `unix-time` implicitly depends on. This results in runtime linker errors when combining `unix-time` with Template Haskell. See https://gitlab.haskell.org/ghc/ghc/-/issues/23533 for an example of this.

We work around the issue by conditionally linking against `mingwex` on Windows. I've guarded this behind a conditional so that it can be removed in the distant future, should `unix-time` ever drop support for these GHC versions.