### PR TITLE
Improve libFFI calls to `gettimeofday()`

### DIFF
--- a/Data/UnixTime/Sys.hsc
+++ b/Data/UnixTime/Sys.hsc
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 
 module Data.UnixTime.Sys (getUnixTime) where
@@ -17,7 +18,7 @@ import Foreign.Storable
 type CTimeVal = ()
 type CTimeZone = ()
 
-foreign import ccall unsafe "gettimeofday"
+foreign import capi unsafe "sys/time.h gettimeofday"
     c_gettimeofday :: Ptr CTimeVal -> Ptr CTimeZone -> IO CInt
 
 -- |

--- a/unix-time.cabal
+++ b/unix-time.cabal
@@ -43,7 +43,7 @@ library
     include-dirs:     cbits
     ghc-options:      -Wall
     build-depends:
-        base >=4 && <5,
+        base >=4.4 && <5,
         bytestring,
         old-time,
         binary


### PR DESCRIPTION
This PR fixes 2 bugs (described in #62) when calling the `gettimeofday()` function from libC.

The first commit uses CApiFFI for `gettimeofday()`.
The second commit uses the correct type for `tv_usec` when peeking `UnixTime`.
