### PR TITLE
Fix MinGW64 linker error by removing _isblank_l declaration

### DIFF
--- a/cbits/win_patch.h
+++ b/cbits/win_patch.h
@@ -118,8 +118,10 @@ long long strtoll_l(const char *nptr, char **endptr, int base, _locale_t locale)
 
 #if HAVE__ISBLANK_L
 #define isblank_l _isblank_l
+#ifndef _isblank_l
 // Needed to avoid -Wimplicit-function-declaration warnings
 int _isblank_l(int c, _locale_t  loc);
+#endif
 #else
 int isblank_l( int c, _locale_t _loc);
 #endif


### PR DESCRIPTION
Remove explicit declaration of _isblank_l function which was causing undefined symbol errors in MinGW64 builds. The function is already defined by the _isblank_l macro when HAVE__ISBLANK_L is set.

Fixes: ld.lld: error: undefined symbol: __local_stdio_printf_options