### PR TITLE
Remove deprecated old-time conversions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog for unix-time
 
+## v0.5.0
+
+* Remove deprecated `old-time` dependency by dropping `fromClockTime` and `toClockTime`
+  [#68](https://github.com/kazu-yamamoto/unix-time/pull/68)
+
 ## v0.4.17
 
 * Fix MinGW64 linker error

--- a/Data/UnixTime.hs
+++ b/Data/UnixTime.hs
@@ -25,9 +25,7 @@ module Data.UnixTime (
 
     -- * Translating time
     fromEpochTime,
-    toEpochTime,
-    fromClockTime,
-    toClockTime,
+    toEpochTime
 ) where
 
 import Data.UnixTime.Conv

--- a/Data/UnixTime/Conv.hs
+++ b/Data/UnixTime/Conv.hs
@@ -9,9 +9,7 @@ module Data.UnixTime.Conv (
     webDateFormat,
     mailDateFormat,
     fromEpochTime,
-    toEpochTime,
-    fromClockTime,
-    toClockTime,
+    toEpochTime
 ) where
 
 import Control.Applicative
@@ -23,7 +21,6 @@ import Foreign.C.Types
 import Foreign.Marshal.Alloc
 import System.IO.Unsafe (unsafePerformIO)
 import System.Posix.Types (EpochTime)
-import System.Time (ClockTime (..))
 
 -- $setup
 -- >>> import Data.Function (on)
@@ -143,19 +140,3 @@ fromEpochTime sec = UnixTime sec 0
 -- From 'UnixTime' to 'EpochTime' ignoring 'utMicroSeconds'.
 toEpochTime :: UnixTime -> EpochTime
 toEpochTime (UnixTime sec _) = sec
-
--- |
--- From 'ClockTime' to 'UnixTime'.
-fromClockTime :: ClockTime -> UnixTime
-fromClockTime (TOD sec psec) = UnixTime sec' usec'
-  where
-    sec' = fromIntegral sec
-    usec' = fromIntegral $ psec `div` 1000000
-
--- |
--- From 'UnixTime' to 'ClockTime'.
-toClockTime :: UnixTime -> ClockTime
-toClockTime (UnixTime sec usec) = TOD sec' psec'
-  where
-    sec' = truncate (toRational sec)
-    psec' = fromIntegral $ usec * 1000000

--- a/unix-time.cabal
+++ b/unix-time.cabal
@@ -1,6 +1,6 @@
 cabal-version:      1.18
 name:               unix-time
-version:            0.4.17
+version:            0.5.0
 license:            BSD3
 license-file:       LICENSE
 maintainer:         Kazu Yamamoto <kazu@iij.ad.jp>

--- a/unix-time.cabal
+++ b/unix-time.cabal
@@ -47,7 +47,6 @@ library
     build-depends:
         base >=4.4 && <5,
         bytestring,
-        old-time,
         binary
 
     if impl(ghc >=7.8)
@@ -74,8 +73,6 @@ test-suite spec
     build-depends:
         base,
         bytestring,
-        old-locale,
-        old-time,
         QuickCheck,
         template-haskell,
         time,


### PR DESCRIPTION
Remove [deprecated old-time]() by dropping conversion helpers.

## Justification

In [Stackage LTS 24.3, unix-time-0.4.17 is used](https://www.stackage.org/lts-24.3/package/unix-time-0.4.17) by:
caster
easy-logger
fast-logger
google-oauth2-jwt
http2
network-control
textlocal
tls

None of those packages is [listed as a reverse dependency of old-time](https://www.stackage.org/lts-24.3/package/old-time-1.1.0.4/revdeps).

This suggests that current Stackage users of unix-time do not depend on old-time directly, and likely do not need the ClockTime conversion helpers.

## Current situation
Because `unix-time` depends on `old-time`, downstream packages get a deprecated transitive dependency even when they do not use old-time e.g. `persistent`:
```
cabal run cabal-plan-submit -- why --production-only ~/persistent/dist-newstyle/cache/plan.json old-time
old-time
paths:
  persistent-2.18.1.0 -> fast-logger-3.2.6 -> unix-time-0.4.17 -> old-time-1.1.1.0
  persistent-mongoDB-2.13.1.0 -> mongoDB-2.7.1.4 -> tls-2.4.1 -> unix-time-0.4.17 -> old-time-1.1.1.0
  persistent-mysql-2.13.1.6 -> monad-logger-0.3.42 -> fast-logger-3.2.6 -> unix-time-0.4.17 -> old-time-1.1.1.0
  persistent-postgresql-2.14.3.0 -> monad-logger-0.3.42 -> fast-logger-3.2.6 -> unix-time-0.4.17 -> old-time-1.1.1.0
  persistent-qq-2.12.0.7 -> persistent-2.18.1.0 -> fast-logger-3.2.6 -> unix-time-0.4.17 -> old-time-1.1.1.0
  persistent-redis-2.13.0.2 -> hedis-0.15.2 -> tls-2.4.1 -> unix-time-0.4.17 -> old-time-1.1.1.0
  persistent-sqlite-2.13.3.1 -> monad-logger-0.3.42 -> fast-logger-3.2.6 -> unix-time-0.4.17 -> old-time-1.1.1.0
```
 and `yesod`:
 ```   
cabal run cabal-plan-submit -- why --production-only ~/yesod/dist-newstyle/cache/plan.json old-time
old-time
paths:
  yesod-1.6.2.2 -> fast-logger-3.2.6 -> unix-time-0.4.17 -> old-time-1.1.1.0
  yesod-auth-1.6.12.0 -> http-client-tls-0.4.0 -> tls-2.4.1 -> unix-time-0.4.17 -> old-time-1.1.1.0
  yesod-auth-oauth-1.6.1 -> yesod-core-1.6.29.1 -> fast-logger-3.2.6 -> unix-time-0.4.17 -> old-time-1.1.1.0
  yesod-bin-1.6.2.4 -> http-client-tls-0.4.0 -> tls-2.4.1 -> unix-time-0.4.17 -> old-time-1.1.1.0
  yesod-core-1.6.29.1 -> fast-logger-3.2.6 -> unix-time-0.4.17 -> old-time-1.1.1.0
  yesod-eventsource-1.6.0.1 -> wai-extra-3.1.18 -> fast-logger-3.2.6 -> unix-time-0.4.17 -> old-time-1.1.1.0
  yesod-form-1.7.9.2 -> persistent-2.18.1.0 -> fast-logger-3.2.6 -> unix-time-0.4.17 -> old-time-1.1.1.0
  yesod-form-multi-1.7.0.2 -> yesod-core-1.6.29.1 -> fast-logger-3.2.6 -> unix-time-0.4.17 -> old-time-1.1.1.0
  yesod-newsfeed-1.7.0.0 -> yesod-core-1.6.29.1 -> fast-logger-3.2.6 -> unix-time-0.4.17 -> old-time-1.1.1.0
  yesod-persistent-1.6.0.8 -> persistent-2.18.1.0 -> fast-logger-3.2.6 -> unix-time-0.4.17 -> old-time-1.1.1.0
  yesod-sitemap-1.6.0 -> yesod-core-1.6.29.1 -> fast-logger-3.2.6 -> unix-time-0.4.17 -> old-time-1.1.1.0
  yesod-static-1.6.1.2 -> yesod-core-1.6.29.1 -> fast-logger-3.2.6 -> unix-time-0.4.17 -> old-time-1.1.1.0
  yesod-websockets-0.3.0.4 -> yesod-core-1.6.29.1 -> fast-logger-3.2.6 -> unix-time-0.4.17 -> old-time-1.1.1.0
```
I am happy to change this to a first deprecating these helpers and removing them in a later release.